### PR TITLE
Wire up root command with config, keyring, and output resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -36,6 +38,7 @@ github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8u
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,18 @@
+package cli
+
+import "github.com/ran-codes/zenodo-cli/internal/config"
+
+// AppContext holds resolved runtime state shared across all subcommands.
+type AppContext struct {
+	Config  *config.Config
+	Keyring *config.Keyring
+	Profile string
+	Token   string
+	BaseURL string
+	Output  string
+	Fields  string
+	Verbose bool
+}
+
+// appCtx is the global resolved context, populated by PersistentPreRunE.
+var appCtx AppContext

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,12 @@
 package cli
 
 import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/ran-codes/zenodo-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -8,7 +14,86 @@ var rootCmd = &cobra.Command{
 	Use:   "zenodo",
 	Short: "CLI for the Zenodo REST API",
 	Long:  "A command-line tool for managing metadata, searching records, and querying assets on Zenodo.",
-	// No Run: root command prints help by default via cobra.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Set up logging.
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		level := slog.LevelWarn
+		if verbose {
+			level = slog.LevelDebug
+		}
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
+		// Load config.
+		cfg, err := config.Load()
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		// Check config file permissions.
+		if warning := config.CheckConfigPermissions(); warning != nil {
+			slog.Warn(warning.Error())
+		}
+
+		// Resolve profile.
+		profileFlag, _ := cmd.Flags().GetString("profile")
+		profile := config.ResolveProfile(profileFlag)
+		if profile == "" {
+			profile = cfg.DefaultProfile()
+		}
+
+		// Set up keyring.
+		kr := config.NewKeyring()
+		if !kr.Available() {
+			slog.Debug("OS keyring not available, using config file fallback for tokens")
+		}
+
+		// Auto-migrate plaintext tokens from config to keyring.
+		kr.MigrateToken(cfg, profile)
+
+		// Resolve token.
+		tokenFlag, _ := cmd.Flags().GetString("token")
+		if tokenFlag != "" {
+			fmt.Fprintln(os.Stderr, "Warning: passing token via --token flag is insecure; prefer ZENODO_TOKEN env var or `zenodo config set token`")
+		}
+		token := config.ResolveTokenFull(tokenFlag, kr, cfg, profile)
+
+		// Resolve base URL.
+		sandbox, _ := cmd.Flags().GetBool("sandbox")
+		baseURL := cfg.ResolveBaseURL(profile, sandbox)
+
+		// Resolve output format.
+		output, _ := cmd.Flags().GetString("output")
+		if output == "" {
+			if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+				output = "table"
+			} else {
+				output = "json"
+			}
+		}
+
+		fields, _ := cmd.Flags().GetString("fields")
+
+		// Populate shared context.
+		appCtx = AppContext{
+			Config:  cfg,
+			Keyring: kr,
+			Profile: profile,
+			Token:   token,
+			BaseURL: baseURL,
+			Output:  output,
+			Fields:  fields,
+			Verbose: verbose,
+		}
+
+		slog.Debug("resolved context",
+			"profile", profile,
+			"base_url", baseURL,
+			"output", output,
+			"has_token", token != "",
+		)
+
+		return nil
+	},
 }
 
 func init() {


### PR DESCRIPTION
## ELI5

Until now the global flags (`--token`, `--profile`, `--sandbox`, `--verbose`, `--output`, `--fields`) were defined but didn't actually do anything. This PR wires them up so that *before* any subcommand runs, the CLI automatically loads your config, figures out which profile/token/server to use, detects whether you're in a terminal or a pipe (to pick table vs JSON output), and warns you if you passed a token on the command line. All of this gets stored in a shared `AppContext` that every future subcommand can read from.

## Summary

- Adds `PersistentPreRunE` to the root cobra command — runs before every subcommand
- Creates `AppContext` struct to hold resolved runtime state (config, keyring, profile, token, base URL, output format, fields, verbose)
- TTY auto-detection via `go-isatty`: table for interactive terminals, JSON when piped
- `--token` flag prints a security warning recommending env var or keyring
- `--verbose` enables debug-level slog output to stderr
- Auto-migrates plaintext tokens to keyring on every run

## Code changes

| File | What |
|------|------|
| `internal/cli/context.go` | New — `AppContext` struct and global `appCtx` |
| `internal/cli/root.go` | `PersistentPreRunE` wiring: config load, profile/token/URL resolution, logging setup, TTY detection |
| `go.mod` / `go.sum` | Added `mattn/go-isatty` |

## Test plan

- [x] `go test ./...` — all 15 tests pass
- [x] `go build ./cmd/zenodo/` compiles
- [x] `zenodo config get default_profile` → `production` (prerun doesn't block config commands)
- [x] `zenodo --verbose config get default_profile` → shows debug log with resolved context
- [x] `zenodo --token test123 config get default_profile` → prints security warning

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)