### PR TITLE
Implement HTTP API client with auth and error handling

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// Client is an HTTP client for the Zenodo API.
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// NewClient creates a new API client.
+func NewClient(baseURL, token string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Get performs a GET request and decodes the JSON response into result.
+func (c *Client) Get(path string, query url.Values, result interface{}) error {
+	return c.do(http.MethodGet, path, query, nil, result)
+}
+
+// Post performs a POST request with a JSON body and decodes the response.
+func (c *Client) Post(path string, body interface{}, result interface{}) error {
+	return c.do(http.MethodPost, path, nil, body, result)
+}
+
+// Put performs a PUT request with a JSON body and decodes the response.
+func (c *Client) Put(path string, body interface{}, result interface{}) error {
+	return c.do(http.MethodPut, path, nil, body, result)
+}
+
+// Delete performs a DELETE request.
+func (c *Client) Delete(path string, result interface{}) error {
+	return c.do(http.MethodDelete, path, nil, nil, result)
+}
+
+func (c *Client) do(method, path string, query url.Values, body interface{}, result interface{}) error {
+	reqURL := c.baseURL + path
+	if query != nil {
+		reqURL += "?" + query.Encode()
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequest(method, reqURL, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	// Auth header.
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	// Content headers.
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	slog.Debug("API request", "method", method, "url", reqURL)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	slog.Debug("API response", "status", resp.StatusCode)
+
+	// Read response body.
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	// Check for error status codes.
+	if resp.StatusCode >= 400 {
+		return parseAPIError(resp.StatusCode, respBody)
+	}
+
+	// 204 No Content — nothing to decode.
+	if resp.StatusCode == http.StatusNoContent || len(respBody) == 0 {
+		return nil
+	}
+
+	// Decode response.
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func parseAPIError(status int, body []byte) error {
+	apiErr := &model.APIError{Status: status}
+
+	// Try to parse structured error from Zenodo.
+	if err := json.Unmarshal(body, apiErr); err != nil {
+		// Couldn't parse — use raw body as message.
+		apiErr.Message = string(body)
+		if apiErr.Message == "" {
+			apiErr.Message = http.StatusText(status)
+		}
+	}
+
+	// Ensure status is set (API might not include it in body).
+	apiErr.Status = status
+
+	if hint := apiErr.Hint(); hint != "" {
+		slog.Warn(hint)
+	}
+
+	return apiErr
+}
+
+// BaseURL returns the client's base URL.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// GetRaw performs a GET request with a custom Accept header and returns raw bytes.
+// Useful for non-JSON formats like BibTeX or DataCite XML.
+func (c *Client) GetRaw(path string, accept string) ([]byte, error) {
+	reqURL := c.baseURL + path
+
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	req.Header.Set("Accept", accept)
+
+	slog.Debug("API request (raw)", "url", reqURL, "accept", accept)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, parseAPIError(resp.StatusCode, body)
+	}
+
+	return body, nil
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestGet_Success(t *testing.T) {
+	expected := map[string]string{"title": "Test Record"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("expected Accept: application/json, got %s", r.Header.Get("Accept"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expected)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	var result map[string]string
+	err := client.Get("/test", nil, &result)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if result["title"] != "Test Record" {
+		t.Errorf("got title %q, want %q", result["title"], "Test Record")
+	}
+}
+
+func TestGet_AuthHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer my-secret" {
+			t.Errorf("expected 'Bearer my-secret', got %q", auth)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "my-secret")
+	err := client.Get("/auth-test", nil, nil)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+}
+
+func TestGet_NoAuthWhenEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "" {
+			t.Errorf("expected no auth header, got %q", auth)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "")
+	err := client.Get("/no-auth", nil, nil)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+}
+
+func TestGet_QueryParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("q") != "test" {
+			t.Errorf("expected q=test, got %q", r.URL.Query().Get("q"))
+		}
+		if r.URL.Query().Get("page") != "2" {
+			t.Errorf("expected page=2, got %q", r.URL.Query().Get("page"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "")
+	q := make(map[string][]string)
+	q["q"] = []string{"test"}
+	q["page"] = []string{"2"}
+	err := client.Get("/search", q, nil)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+}
+
+func TestPost_SendsJSON(t *testing.T) {
+	type reqBody struct {
+		Title string `json:"title"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		var body reqBody
+		json.NewDecoder(r.Body).Decode(&body)
+		if body.Title != "New Title" {
+			t.Errorf("got title %q, want %q", body.Title, "New Title")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"id": "123"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	var result map[string]string
+	err := client.Post("/create", reqBody{Title: "New Title"}, &result)
+	if err != nil {
+		t.Fatalf("Post() error: %v", err)
+	}
+	if result["id"] != "123" {
+		t.Errorf("got id %q, want %q", result["id"], "123")
+	}
+}
+
+func TestPut_SendsJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	err := client.Put("/update", map[string]string{"title": "Updated"}, nil)
+	if err != nil {
+		t.Fatalf("Put() error: %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	err := client.Delete("/remove", nil)
+	if err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+}
+
+func TestAPIError_Structured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(model.APIError{
+			Status:  400,
+			Message: "Validation error",
+			Errors: []model.Detail{
+				{Field: "title", Message: "required"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	err := client.Get("/bad", nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("expected *model.APIError, got %T", err)
+	}
+	if apiErr.Status != 400 {
+		t.Errorf("status = %d, want 400", apiErr.Status)
+	}
+	if apiErr.Message != "Validation error" {
+		t.Errorf("message = %q, want %q", apiErr.Message, "Validation error")
+	}
+	if len(apiErr.Errors) != 1 || apiErr.Errors[0].Field != "title" {
+		t.Errorf("expected field error on title, got %+v", apiErr.Errors)
+	}
+}
+
+func TestAPIError_401Hint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"status":401,"message":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "bad-token")
+	err := client.Get("/secret", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr := err.(*model.APIError)
+	if apiErr.Status != 401 {
+		t.Errorf("status = %d, want 401", apiErr.Status)
+	}
+	if hint := apiErr.Hint(); hint == "" {
+		t.Error("expected hint for 401, got empty")
+	}
+}
+
+func TestAPIError_NonJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	err := client.Get("/crash", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr := err.(*model.APIError)
+	if apiErr.Status != 500 {
+		t.Errorf("status = %d, want 500", apiErr.Status)
+	}
+}
+
+func TestGetRaw(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accept := r.Header.Get("Accept")
+		if accept != "application/x-bibtex" {
+			t.Errorf("expected Accept application/x-bibtex, got %q", accept)
+		}
+		w.Write([]byte("@article{test, title={Test}}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	data, err := client.GetRaw("/record/123", "application/x-bibtex")
+	if err != nil {
+		t.Fatalf("GetRaw() error: %v", err)
+	}
+	if string(data) != "@article{test, title={Test}}" {
+		t.Errorf("got %q", string(data))
+	}
+}

--- a/internal/model/error.go
+++ b/internal/model/error.go
@@ -1,0 +1,40 @@
+package model
+
+import "fmt"
+
+// APIError represents an error response from the Zenodo API.
+type APIError struct {
+	Status  int      `json:"status"`
+	Message string   `json:"message"`
+	Errors  []Detail `json:"errors,omitempty"`
+}
+
+// Detail is a single field-level error from the API.
+type Detail struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e *APIError) Error() string {
+	msg := fmt.Sprintf("API error %d: %s", e.Status, e.Message)
+	for _, d := range e.Errors {
+		msg += fmt.Sprintf("\n  - %s: %s", d.Field, d.Message)
+	}
+	return msg
+}
+
+// Hint returns a user-friendly suggestion based on the status code.
+func (e *APIError) Hint() string {
+	switch e.Status {
+	case 401:
+		return "Check that your token is valid. Set it with: zenodo config set token <TOKEN>"
+	case 403:
+		return "Your token may lack required scopes (deposit:write, deposit:actions). Generate a new token at https://zenodo.org/account/settings/applications/"
+	case 404:
+		return "Record not found. Check the ID and ensure you have access."
+	case 429:
+		return "Rate limit exceeded. The CLI will automatically retry; if this persists, reduce request frequency."
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## ELI5

Every command that talks to Zenodo needs to send HTTP requests — add the right auth header, send/receive JSON, and understand error responses. This PR builds a shared HTTP client so each command doesn't have to reinvent that wheel. You call `client.Get("/records/123", ...)` and it handles auth, JSON parsing, and turns Zenodo errors into clear messages like "401: check your token" or "403: you need the deposit:write scope."

## Summary

- Shared `Client` struct with `Get()`, `Post()`, `Put()`, `Delete()` JSON helpers
- `GetRaw()` for non-JSON formats (BibTeX, DataCite XML) with custom Accept headers
- Bearer token auth injection (omitted when no token set)
- `APIError` struct parses Zenodo's structured error responses with field-level details
- User-friendly hints for common HTTP errors (401, 403, 404, 429)
- Graceful handling of non-JSON error bodies and 204 No Content

## Code changes

| File | What |
|------|------|
| `internal/api/client.go` | `Client` struct, `NewClient()`, `Get/Post/Put/Delete/GetRaw`, `parseAPIError()` |
| `internal/model/error.go` | `APIError` struct with `Error()` and `Hint()` methods |
| `internal/api/client_test.go` | 11 tests: GET/POST/PUT/DELETE success, auth header, no-auth, query params, structured errors, 401 hint, non-JSON errors, raw response |

## Test plan

- [x] `go test ./internal/api/ -v` — all 11 tests pass
- [x] `go test ./...` — all 26 tests pass across all packages
- [x] `go build ./cmd/zenodo/` compiles

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)