### PR TITLE
Implement rate limiter with dual token buckets and header parsing

### DIFF
--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimiter implements dual token bucket rate limiting for the Zenodo API.
+// General bucket: 100 req/min, Search bucket: 30 req/min.
+type RateLimiter struct {
+	mu      sync.Mutex
+	general *bucket
+	search  *bucket
+}
+
+type bucket struct {
+	tokens    float64
+	maxTokens float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
+}
+
+func newBucket(maxTokens float64, perMinute float64) *bucket {
+	return &bucket{
+		tokens:     maxTokens,
+		maxTokens:  maxTokens,
+		refillRate: perMinute / 60.0,
+		lastRefill: time.Now(),
+	}
+}
+
+func (b *bucket) refill() {
+	now := time.Now()
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	b.tokens += elapsed * b.refillRate
+	if b.tokens > b.maxTokens {
+		b.tokens = b.maxTokens
+	}
+	b.lastRefill = now
+}
+
+// waitDuration returns how long to wait before a token is available.
+func (b *bucket) waitDuration() time.Duration {
+	if b.tokens >= 1 {
+		return 0
+	}
+	deficit := 1.0 - b.tokens
+	return time.Duration(deficit/b.refillRate*1000) * time.Millisecond
+}
+
+func (b *bucket) consume() {
+	b.tokens--
+}
+
+// NewRateLimiter creates a rate limiter with Zenodo's limits.
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		general: newBucket(100, 100),
+		search:  newBucket(30, 30),
+	}
+}
+
+// isSearchPath returns true if the path hits a search-limited endpoint.
+func isSearchPath(path string) bool {
+	searchPrefixes := []string{"/records", "/communities", "/licenses"}
+	for _, prefix := range searchPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Wait blocks until the request is allowed under rate limits.
+func (rl *RateLimiter) Wait(path string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	// Refill both buckets.
+	rl.general.refill()
+	rl.search.refill()
+
+	// Check general bucket.
+	if wait := rl.general.waitDuration(); wait > 0 {
+		slog.Info("rate limiting: waiting for general bucket", "wait", wait)
+		rl.mu.Unlock()
+		time.Sleep(wait)
+		rl.mu.Lock()
+		rl.general.refill()
+	}
+
+	// Check search bucket for search endpoints.
+	if isSearchPath(path) {
+		if wait := rl.search.waitDuration(); wait > 0 {
+			slog.Info("rate limiting: waiting for search bucket", "wait", wait)
+			rl.mu.Unlock()
+			time.Sleep(wait)
+			rl.mu.Lock()
+			rl.search.refill()
+		}
+		rl.search.consume()
+	}
+
+	rl.general.consume()
+}
+
+// UpdateFromHeaders reads X-RateLimit-Remaining and X-RateLimit-Reset headers
+// to adjust the rate limiter state based on server feedback.
+func (rl *RateLimiter) UpdateFromHeaders(resp *http.Response, path string) {
+	if resp == nil {
+		return
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	remaining := resp.Header.Get("X-RateLimit-Remaining")
+	reset := resp.Header.Get("X-RateLimit-Reset")
+
+	if remaining == "" {
+		return
+	}
+
+	rem, err := strconv.ParseFloat(remaining, 64)
+	if err != nil {
+		return
+	}
+
+	// Update the appropriate bucket with server-reported remaining tokens.
+	if isSearchPath(path) && rem < rl.search.tokens {
+		slog.Debug("rate limit: server reports lower search remaining", "remaining", rem)
+		rl.search.tokens = rem
+	}
+
+	if rem < rl.general.tokens {
+		slog.Debug("rate limit: server reports lower general remaining", "remaining", rem)
+		rl.general.tokens = rem
+	}
+
+	// If reset header is present, use it to schedule refill.
+	if reset != "" {
+		resetTime, err := strconv.ParseInt(reset, 10, 64)
+		if err == nil {
+			resetAt := time.Unix(resetTime, 0)
+			untilReset := time.Until(resetAt)
+			if untilReset > 0 && rem <= 5 {
+				slog.Warn("rate limit: approaching limit, server resets in", "seconds", untilReset.Seconds(), "remaining", rem)
+			}
+		}
+	}
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	rl := NewRateLimiter()
+	if rl.general.maxTokens != 100 {
+		t.Errorf("general max = %f, want 100", rl.general.maxTokens)
+	}
+	if rl.search.maxTokens != 30 {
+		t.Errorf("search max = %f, want 30", rl.search.maxTokens)
+	}
+}
+
+func TestIsSearchPath(t *testing.T) {
+	tests := []struct {
+		path   string
+		search bool
+	}{
+		{"/records", true},
+		{"/records/123", true},
+		{"/communities", true},
+		{"/licenses", true},
+		{"/deposit/depositions", false},
+		{"/api/user/records", false},
+	}
+	for _, tt := range tests {
+		if got := isSearchPath(tt.path); got != tt.search {
+			t.Errorf("isSearchPath(%q) = %v, want %v", tt.path, got, tt.search)
+		}
+	}
+}
+
+func TestRateLimiter_GeneralConsumes(t *testing.T) {
+	rl := NewRateLimiter()
+
+	// Consume a general token.
+	startTokens := rl.general.tokens
+	rl.Wait("/deposit/depositions/123")
+
+	rl.mu.Lock()
+	after := rl.general.tokens
+	rl.mu.Unlock()
+
+	// Should have consumed ~1 token (might refill a tiny amount).
+	if after > startTokens-0.5 {
+		t.Errorf("expected general tokens to decrease, before=%f after=%f", startTokens, after)
+	}
+}
+
+func TestRateLimiter_SearchConsumesBoth(t *testing.T) {
+	rl := NewRateLimiter()
+
+	generalBefore := rl.general.tokens
+	searchBefore := rl.search.tokens
+
+	rl.Wait("/records")
+
+	rl.mu.Lock()
+	generalAfter := rl.general.tokens
+	searchAfter := rl.search.tokens
+	rl.mu.Unlock()
+
+	if generalAfter > generalBefore-0.5 {
+		t.Errorf("expected general tokens to decrease, before=%f after=%f", generalBefore, generalAfter)
+	}
+	if searchAfter > searchBefore-0.5 {
+		t.Errorf("expected search tokens to decrease, before=%f after=%f", searchBefore, searchAfter)
+	}
+}
+
+func TestBucket_Refill(t *testing.T) {
+	b := newBucket(10, 60) // 1 token per second
+	b.tokens = 0
+	b.lastRefill = time.Now().Add(-2 * time.Second) // 2 seconds ago
+
+	b.refill()
+
+	// Should have ~2 tokens after refill.
+	if b.tokens < 1.5 || b.tokens > 2.5 {
+		t.Errorf("expected ~2 tokens after 2s refill, got %f", b.tokens)
+	}
+}
+
+func TestBucket_RefillCapped(t *testing.T) {
+	b := newBucket(10, 60)
+	b.tokens = 10
+	b.lastRefill = time.Now().Add(-10 * time.Second)
+
+	b.refill()
+
+	if b.tokens != 10 {
+		t.Errorf("tokens should be capped at max, got %f", b.tokens)
+	}
+}
+
+func TestBucket_WaitDuration(t *testing.T) {
+	b := newBucket(100, 60) // 1 token per second
+	b.tokens = 0.5
+
+	wait := b.waitDuration()
+	// Need 0.5 more tokens at 1/sec = ~500ms
+	if wait < 400*time.Millisecond || wait > 600*time.Millisecond {
+		t.Errorf("expected ~500ms wait, got %v", wait)
+	}
+
+	b.tokens = 5
+	wait = b.waitDuration()
+	if wait != 0 {
+		t.Errorf("expected 0 wait with tokens available, got %v", wait)
+	}
+}
+
+func TestUpdateFromHeaders(t *testing.T) {
+	rl := NewRateLimiter()
+
+	resp := &http.Response{
+		Header: http.Header{
+			"X-Ratelimit-Remaining": []string{"5"},
+		},
+	}
+
+	rl.UpdateFromHeaders(resp, "/records")
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	if rl.general.tokens > 5.5 {
+		t.Errorf("expected general tokens <=5 after header update, got %f", rl.general.tokens)
+	}
+	if rl.search.tokens > 5.5 {
+		t.Errorf("expected search tokens <=5 after header update, got %f", rl.search.tokens)
+	}
+}
+
+func TestUpdateFromHeaders_Nil(t *testing.T) {
+	rl := NewRateLimiter()
+	// Should not panic.
+	rl.UpdateFromHeaders(nil, "/test")
+}


### PR DESCRIPTION
## ELI5

Zenodo limits how many API requests you can make per minute (100 general, 30 for searches). If you blow past those limits, your requests get rejected. This PR adds an automatic speed governor inside the HTTP client — before every request, it checks if you have "tokens" left in your bucket. If not, it waits the right amount of time. It also reads Zenodo's response headers to stay in sync with the server's actual count. You never have to think about rate limits; the CLI handles it.

## Summary

- Dual token bucket rate limiter: general (100/min) and search (30/min)
- Search paths (`/records`, `/communities`, `/licenses`) consume from both buckets
- Proactive backoff: sleeps before sending if tokens exhausted
- Server feedback: parses `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers
- Integrated into `Client.do()` and `Client.GetRaw()` — every request is rate-limited automatically
- Logs when throttling occurs

## Code changes

| File | What |
|------|------|
| `internal/api/ratelimit.go` | `RateLimiter`, dual `bucket`, `Wait()`, `UpdateFromHeaders()`, `isSearchPath()` |
| `internal/api/ratelimit_test.go` | 9 tests: creation, path detection, general/search consumption, refill, cap, wait duration, header updates, nil safety |
| `internal/api/client.go` | Added `rateLimiter` field, `Wait()` before requests, `UpdateFromHeaders()` after responses |

## Test plan

- [x] `go test ./...` — all 35 tests pass
- [x] `go build ./cmd/zenodo/` compiles

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)