### PR TITLE
Define model structs for records, communities, licenses, and stats

### DIFF
--- a/internal/model/access.go
+++ b/internal/model/access.go
@@ -1,0 +1,16 @@
+package model
+
+import "time"
+
+// AccessLink represents a share/access link for a record.
+type AccessLink struct {
+	ID        string    `json:"id"`
+	Token     string    `json:"token,omitempty"`
+	Created   time.Time `json:"created"`
+	Links     Links     `json:"links,omitempty"`
+}
+
+// AccessLinkList is the response from the access links endpoint.
+type AccessLinkList struct {
+	Hits []AccessLink `json:"hits"`
+}

--- a/internal/model/community.go
+++ b/internal/model/community.go
@@ -1,0 +1,28 @@
+package model
+
+import "time"
+
+// Community represents a Zenodo community.
+type Community struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description,omitempty"`
+	PageURL     string    `json:"page,omitempty"`
+	CurationPolicy string `json:"curation_policy,omitempty"`
+	LogoURL     string    `json:"logo_url,omitempty"`
+	Created     time.Time `json:"created"`
+	Updated     time.Time `json:"updated"`
+	Links       Links     `json:"links,omitempty"`
+}
+
+// CommunitySearchResult is the paginated response from communities search.
+type CommunitySearchResult struct {
+	Hits  CommunityHits `json:"hits"`
+	Links Links         `json:"links,omitempty"`
+}
+
+// CommunityHits contains the search result hits and total count.
+type CommunityHits struct {
+	Hits  []Community `json:"hits"`
+	Total int         `json:"total"`
+}

--- a/internal/model/license.go
+++ b/internal/model/license.go
@@ -1,0 +1,27 @@
+package model
+
+// License represents a Zenodo license.
+type License struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	URL         string `json:"url,omitempty"`
+	Family      string `json:"family,omitempty"`
+	Domain      string `json:"domain_content,omitempty"`
+	DomainData  string `json:"domain_data,omitempty"`
+	DomainSW    string `json:"domain_software,omitempty"`
+	Maintainer  string `json:"maintainer,omitempty"`
+	ODConformance string `json:"od_conformance,omitempty"`
+	OSIApproved bool   `json:"osi_approved,omitempty"`
+}
+
+// LicenseSearchResult is the paginated response from licenses search.
+type LicenseSearchResult struct {
+	Hits  LicenseHits `json:"hits"`
+	Links Links       `json:"links,omitempty"`
+}
+
+// LicenseHits contains the search result hits and total count.
+type LicenseHits struct {
+	Hits  []License `json:"hits"`
+	Total int       `json:"total"`
+}

--- a/internal/model/record.go
+++ b/internal/model/record.go
@@ -1,0 +1,161 @@
+package model
+
+import "time"
+
+// Record represents a Zenodo published record.
+type Record struct {
+	ID          int       `json:"id"`
+	ConceptID   int       `json:"conceptrecid,omitempty"`
+	DOI         string    `json:"doi,omitempty"`
+	ConceptDOI  string    `json:"conceptdoi,omitempty"`
+	Title       string    `json:"title,omitempty"`
+	Metadata    Metadata  `json:"metadata"`
+	Stats       Stats     `json:"stats,omitempty"`
+	Links       Links     `json:"links,omitempty"`
+	Created     time.Time `json:"created"`
+	Updated     time.Time `json:"updated"`
+	Revision    int       `json:"revision"`
+	State       string    `json:"state,omitempty"`
+	Submitted   bool      `json:"submitted,omitempty"`
+}
+
+// Deposition represents a Zenodo deposition (draft or published).
+type Deposition struct {
+	ID        int       `json:"id"`
+	ConceptID int       `json:"conceptrecid,omitempty"`
+	DOI       string    `json:"doi,omitempty"`
+	DOIURL    string    `json:"doi_url,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	Metadata  Metadata  `json:"metadata"`
+	Links     Links     `json:"links,omitempty"`
+	State     string    `json:"state,omitempty"`
+	Submitted bool      `json:"submitted"`
+	Created   time.Time `json:"created"`
+	Modified  time.Time `json:"modified"`
+}
+
+// Metadata contains the bibliographic metadata for a record or deposition.
+type Metadata struct {
+	Title               string              `json:"title,omitempty"`
+	Description         string              `json:"description,omitempty"`
+	UploadType          string              `json:"upload_type,omitempty"`
+	PublicationType     string              `json:"publication_type,omitempty"`
+	ImageType           string              `json:"image_type,omitempty"`
+	PublicationDate     string              `json:"publication_date,omitempty"`
+	AccessRight         string              `json:"access_right,omitempty"`
+	License             string              `json:"license,omitempty"`
+	EmbargoDate         string              `json:"embargo_date,omitempty"`
+	AccessConditions    string              `json:"access_conditions,omitempty"`
+	DOI                 string              `json:"doi,omitempty"`
+	PrereserveDOI       *PrereserveDOI      `json:"prereserve_doi,omitempty"`
+	Keywords            []string            `json:"keywords,omitempty"`
+	Notes               string              `json:"notes,omitempty"`
+	Version             string              `json:"version,omitempty"`
+	Language            string              `json:"language,omitempty"`
+	Creators            []Creator           `json:"creators,omitempty"`
+	Contributors        []Contributor       `json:"contributors,omitempty"`
+	RelatedIdentifiers  []RelatedIdentifier `json:"related_identifiers,omitempty"`
+	Communities         []CommunityRef      `json:"communities,omitempty"`
+	Grants              []Grant             `json:"grants,omitempty"`
+	JournalTitle        string              `json:"journal_title,omitempty"`
+	JournalVolume       string              `json:"journal_volume,omitempty"`
+	JournalIssue        string              `json:"journal_issue,omitempty"`
+	JournalPages        string              `json:"journal_pages,omitempty"`
+	ConferenceTitle     string              `json:"conference_title,omitempty"`
+	ConferenceAcronym   string              `json:"conference_acronym,omitempty"`
+	ConferenceURL       string              `json:"conference_url,omitempty"`
+	ConferenceDates     string              `json:"conference_dates,omitempty"`
+	ConferencePlace     string              `json:"conference_place,omitempty"`
+	ConferenceSession   string              `json:"conference_session,omitempty"`
+	ConferenceSessionPart string            `json:"conference_session_part,omitempty"`
+	ImprintISBN         string              `json:"imprint_isbn,omitempty"`
+	ImprintPlace        string              `json:"imprint_place,omitempty"`
+	ImprintPublisher    string              `json:"imprint_publisher,omitempty"`
+	PartOfTitle         string              `json:"partof_title,omitempty"`
+	PartOfPages         string              `json:"partof_pages,omitempty"`
+	ThesisSupervisors   []Creator           `json:"thesis_supervisors,omitempty"`
+	ThesisUniversity    string              `json:"thesis_university,omitempty"`
+	Subjects            []Subject           `json:"subjects,omitempty"`
+	References          []string            `json:"references,omitempty"`
+}
+
+// Creator represents a record creator.
+type Creator struct {
+	Name        string `json:"name"`
+	Affiliation string `json:"affiliation,omitempty"`
+	ORCID       string `json:"orcid,omitempty"`
+	GND         string `json:"gnd,omitempty"`
+}
+
+// Contributor represents a record contributor.
+type Contributor struct {
+	Name        string `json:"name"`
+	Affiliation string `json:"affiliation,omitempty"`
+	ORCID       string `json:"orcid,omitempty"`
+	GND         string `json:"gnd,omitempty"`
+	Type        string `json:"type"`
+}
+
+// RelatedIdentifier links to related resources.
+type RelatedIdentifier struct {
+	Identifier string `json:"identifier"`
+	Relation   string `json:"relation"`
+	Scheme     string `json:"scheme,omitempty"`
+}
+
+// CommunityRef is a reference to a community by identifier.
+type CommunityRef struct {
+	Identifier string `json:"identifier"`
+}
+
+// Grant represents a funding grant.
+type Grant struct {
+	ID string `json:"id,omitempty"`
+}
+
+// PrereserveDOI holds a pre-reserved DOI.
+type PrereserveDOI struct {
+	DOI  string `json:"doi"`
+	ID   int    `json:"recid"`
+}
+
+// Subject represents a subject classification.
+type Subject struct {
+	Term       string `json:"term"`
+	Identifier string `json:"identifier"`
+	Scheme     string `json:"scheme"`
+}
+
+// Links contains HATEOAS links from the API.
+type Links struct {
+	Self         string `json:"self,omitempty"`
+	HTML         string `json:"html,omitempty"`
+	DOI          string `json:"doi,omitempty"`
+	Bucket       string `json:"bucket,omitempty"`
+	Publish      string `json:"publish,omitempty"`
+	Edit         string `json:"edit,omitempty"`
+	Discard      string `json:"discard,omitempty"`
+	NewVersion   string `json:"newversion,omitempty"`
+	LatestDraft  string `json:"latest_draft,omitempty"`
+	Latest       string `json:"latest,omitempty"`
+	LatestHTML   string `json:"latest_html,omitempty"`
+	Versions     string `json:"versions,omitempty"`
+	AccessLinks  string `json:"access_links,omitempty"`
+}
+
+// RecordSearchResult is the paginated response from search endpoints.
+type RecordSearchResult struct {
+	Hits  RecordHits `json:"hits"`
+	Links Links      `json:"links,omitempty"`
+}
+
+// RecordHits contains the search result hits and total count.
+type RecordHits struct {
+	Hits  []Record `json:"hits"`
+	Total int      `json:"total"`
+}
+
+// VersionList is the response from the versions endpoint.
+type VersionList struct {
+	Hits []Record `json:"hits"`
+}

--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -1,0 +1,11 @@
+package model
+
+// Stats holds download and view statistics for a record.
+type Stats struct {
+	Downloads       int `json:"downloads"`
+	Views           int `json:"views"`
+	UniqueDownloads int `json:"unique_downloads"`
+	UniqueViews     int `json:"unique_views"`
+	VersionDownloads int `json:"version_downloads"`
+	VersionViews    int `json:"version_views"`
+}


### PR DESCRIPTION
## ELI5

When the CLI gets JSON back from Zenodo, it needs Go structs to pour that data into — like molds for the data. This PR defines all those molds: records (with their metadata, creators, keywords, etc.), communities, licenses, download/view stats, and access links. Every future command that reads from or writes to Zenodo will use these types.

## Summary

- Full model coverage for all Zenodo API entities used in v0.1
- JSON tags match Zenodo API field names exactly
- Paginated search result wrappers for records, communities, licenses
- Links struct for HATEOAS API navigation

## Code changes

| File | What |
|------|------|
| `internal/model/record.go` | `Record`, `Deposition`, `Metadata`, `Creator`, `Contributor`, `RelatedIdentifier`, `CommunityRef`, `Grant`, `Subject`, `Links`, search result wrappers |
| `internal/model/community.go` | `Community`, `CommunitySearchResult` |
| `internal/model/license.go` | `License`, `LicenseSearchResult` |
| `internal/model/stats.go` | `Stats` (downloads, views, unique counts) |
| `internal/model/access.go` | `AccessLink`, `AccessLinkList` |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` — all 35 tests pass (no regressions)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)