### PR TITLE
Implement records API methods (list, search, get, versions)

### DIFF
--- a/internal/api/records.go
+++ b/internal/api/records.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// ListUserRecords returns the authenticated user's records and drafts.
+func (c *Client) ListUserRecords(params RecordListParams) (*model.RecordSearchResult, error) {
+	query := params.toQuery()
+	var result model.RecordSearchResult
+	if err := c.Get("/api/records", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SearchRecords searches published records with an Elasticsearch query.
+func (c *Client) SearchRecords(q string, params RecordListParams) (*model.RecordSearchResult, error) {
+	query := params.toQuery()
+	if q != "" {
+		query.Set("q", q)
+	}
+	var result model.RecordSearchResult
+	if err := c.Get("/records/", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetRecord retrieves a single published record by ID.
+func (c *Client) GetRecord(id int) (*model.Record, error) {
+	var result model.Record
+	if err := c.Get(fmt.Sprintf("/records/%d", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ListVersions returns all versions of a record.
+func (c *Client) ListVersions(id int) (*model.RecordSearchResult, error) {
+	var result model.RecordSearchResult
+	if err := c.Get(fmt.Sprintf("/api/records/%d/versions", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// RecordListParams holds query parameters for listing/searching records.
+type RecordListParams struct {
+	Page      int
+	Size      int
+	Status    string
+	Community string
+	Sort      string
+}
+
+func (p RecordListParams) toQuery() url.Values {
+	q := url.Values{}
+	if p.Page > 0 {
+		q.Set("page", strconv.Itoa(p.Page))
+	}
+	if p.Size > 0 {
+		q.Set("size", strconv.Itoa(p.Size))
+	} else {
+		q.Set("size", "100") // Max page size for authenticated requests.
+	}
+	if p.Status != "" {
+		q.Set("status", p.Status)
+	}
+	if p.Community != "" {
+		q.Set("communities", p.Community)
+	}
+	if p.Sort != "" {
+		q.Set("sort", p.Sort)
+	}
+	return q
+}
+
+// PaginateAll fetches all pages of results up to the 10k ceiling.
+// It calls fetchPage repeatedly, which should return (result, error).
+func PaginateAll(fetchPage func(page int) (*model.RecordSearchResult, error)) ([]model.Record, int, error) {
+	var allRecords []model.Record
+	const maxResults = 10000
+	const pageSize = 100
+
+	for page := 1; ; page++ {
+		result, err := fetchPage(page)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		allRecords = append(allRecords, result.Hits.Hits...)
+
+		// Check if we've fetched all results or hit the ceiling.
+		if len(allRecords) >= result.Hits.Total || len(result.Hits.Hits) < pageSize {
+			return allRecords, result.Hits.Total, nil
+		}
+		if len(allRecords) >= maxResults {
+			return allRecords, result.Hits.Total, fmt.Errorf("results truncated at %d (total: %d); narrow your search", maxResults, result.Hits.Total)
+		}
+	}
+}

--- a/internal/api/records_test.go
+++ b/internal/api/records_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestSearchRecords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/records/" {
+			t.Errorf("path = %q, want /records/", r.URL.Path)
+		}
+		if r.URL.Query().Get("q") != "climate" {
+			t.Errorf("q = %q, want climate", r.URL.Query().Get("q"))
+		}
+		json.NewEncoder(w).Encode(model.RecordSearchResult{
+			Hits: model.RecordHits{
+				Hits:  []model.Record{{ID: 1, Metadata: model.Metadata{Title: "Climate Study"}}},
+				Total: 1,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	result, err := client.SearchRecords("climate", RecordListParams{})
+	if err != nil {
+		t.Fatalf("SearchRecords() error: %v", err)
+	}
+	if result.Hits.Total != 1 {
+		t.Errorf("total = %d, want 1", result.Hits.Total)
+	}
+	if result.Hits.Hits[0].Metadata.Title != "Climate Study" {
+		t.Errorf("title = %q", result.Hits.Hits[0].Metadata.Title)
+	}
+}
+
+func TestGetRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/records/12345" {
+			t.Errorf("path = %q, want /records/12345", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.Record{
+			ID:       12345,
+			Metadata: model.Metadata{Title: "My Record"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	record, err := client.GetRecord(12345)
+	if err != nil {
+		t.Fatalf("GetRecord() error: %v", err)
+	}
+	if record.ID != 12345 {
+		t.Errorf("ID = %d, want 12345", record.ID)
+	}
+}
+
+func TestListUserRecords(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/records" {
+			t.Errorf("path = %q, want /api/records", r.URL.Path)
+		}
+		if r.URL.Query().Get("status") != "draft" {
+			t.Errorf("status = %q, want draft", r.URL.Query().Get("status"))
+		}
+		json.NewEncoder(w).Encode(model.RecordSearchResult{
+			Hits: model.RecordHits{
+				Hits:  []model.Record{{ID: 1}},
+				Total: 1,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	result, err := client.ListUserRecords(RecordListParams{Status: "draft"})
+	if err != nil {
+		t.Fatalf("ListUserRecords() error: %v", err)
+	}
+	if result.Hits.Total != 1 {
+		t.Errorf("total = %d, want 1", result.Hits.Total)
+	}
+}
+
+func TestListVersions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/records/100/versions" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.RecordSearchResult{
+			Hits: model.RecordHits{
+				Hits:  []model.Record{{ID: 100}, {ID: 101}},
+				Total: 2,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	result, err := client.ListVersions(100)
+	if err != nil {
+		t.Fatalf("ListVersions() error: %v", err)
+	}
+	if len(result.Hits.Hits) != 2 {
+		t.Errorf("versions count = %d, want 2", len(result.Hits.Hits))
+	}
+}
+
+func TestRecordListParams_ToQuery(t *testing.T) {
+	p := RecordListParams{
+		Page:      2,
+		Size:      50,
+		Status:    "published",
+		Community: "my-org",
+		Sort:      "mostrecent",
+	}
+	q := p.toQuery()
+
+	if q.Get("page") != "2" {
+		t.Errorf("page = %q", q.Get("page"))
+	}
+	if q.Get("size") != "50" {
+		t.Errorf("size = %q", q.Get("size"))
+	}
+	if q.Get("status") != "published" {
+		t.Errorf("status = %q", q.Get("status"))
+	}
+	if q.Get("communities") != "my-org" {
+		t.Errorf("communities = %q", q.Get("communities"))
+	}
+}
+
+func TestPaginateAll(t *testing.T) {
+	callCount := 0
+	records, total, err := PaginateAll(func(page int) (*model.RecordSearchResult, error) {
+		callCount++
+		if page == 1 {
+			hits := make([]model.Record, 100)
+			for i := range hits {
+				hits[i] = model.Record{ID: i}
+			}
+			return &model.RecordSearchResult{
+				Hits: model.RecordHits{Hits: hits, Total: 150},
+			}, nil
+		}
+		hits := make([]model.Record, 50)
+		for i := range hits {
+			hits[i] = model.Record{ID: 100 + i}
+		}
+		return &model.RecordSearchResult{
+			Hits: model.RecordHits{Hits: hits, Total: 150},
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("PaginateAll() error: %v", err)
+	}
+	if len(records) != 150 {
+		t.Errorf("records = %d, want 150", len(records))
+	}
+	if total != 150 {
+		t.Errorf("total = %d, want 150", total)
+	}
+	if callCount != 2 {
+		t.Errorf("calls = %d, want 2", callCount)
+	}
+}


### PR DESCRIPTION
## ELI5

This is the code that actually talks to Zenodo's records endpoints — list your records, search all published records, get a single record by ID, and list all versions of a record. It also includes a generic auto-paginator that keeps fetching pages until it has all results (up to 10k max). These methods are what the CLI commands will call in Issue #11.

## Summary

- `ListUserRecords()`, `SearchRecords()`, `GetRecord()`, `ListVersions()`
- `RecordListParams` query builder with page/size/status/community/sort
- `PaginateAll()` generic pagination helper with 10k ceiling and truncation warning
- 6 tests with httptest mock server

## Code changes

| File | What |
|------|------|
| `internal/api/records.go` | 4 API methods + `RecordListParams` + `PaginateAll()` |
| `internal/api/records_test.go` | 6 tests: search, get, list, versions, params, multi-page pagination |

## Test plan

- [x] `go test ./...` — all 51 tests pass
- [x] `go build ./...` compiles

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)