### PR TITLE
Implement communities, licenses, and access links API methods

### DIFF
--- a/internal/api/access.go
+++ b/internal/api/access.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// ListAccessLinks returns the share/access links for a record.
+func (c *Client) ListAccessLinks(recordID int) ([]model.AccessLink, error) {
+	var result model.AccessLinkList
+	if err := c.Get(fmt.Sprintf("/api/records/%d/access/links", recordID), nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Hits, nil
+}

--- a/internal/api/access_test.go
+++ b/internal/api/access_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestListAccessLinks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/records/123/access/links" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.AccessLinkList{
+			Hits: []model.AccessLink{{ID: "link-1"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	links, err := client.ListAccessLinks(123)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("links = %d", len(links))
+	}
+	if links[0].ID != "link-1" {
+		t.Errorf("id = %q", links[0].ID)
+	}
+}

--- a/internal/api/communities.go
+++ b/internal/api/communities.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// SearchCommunities searches or lists communities.
+func (c *Client) SearchCommunities(q string, page, size int) (*model.CommunitySearchResult, error) {
+	query := url.Values{}
+	if q != "" {
+		query.Set("q", q)
+	}
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if size > 0 {
+		query.Set("size", strconv.Itoa(size))
+	} else {
+		query.Set("size", "100")
+	}
+
+	var result model.CommunitySearchResult
+	if err := c.Get("/communities/", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/api/communities_test.go
+++ b/internal/api/communities_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestSearchCommunities(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/communities/" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("q") != "open science" {
+			t.Errorf("q = %q", r.URL.Query().Get("q"))
+		}
+		json.NewEncoder(w).Encode(model.CommunitySearchResult{
+			Hits: model.CommunityHits{
+				Hits:  []model.Community{{ID: "open-sci", Title: "Open Science"}},
+				Total: 1,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	result, err := client.SearchCommunities("open science", 0, 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if result.Hits.Total != 1 {
+		t.Errorf("total = %d", result.Hits.Total)
+	}
+	if result.Hits.Hits[0].ID != "open-sci" {
+		t.Errorf("id = %q", result.Hits.Hits[0].ID)
+	}
+}

--- a/internal/api/licenses.go
+++ b/internal/api/licenses.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// SearchLicenses searches available licenses.
+func (c *Client) SearchLicenses(q string, page, size int) (*model.LicenseSearchResult, error) {
+	query := url.Values{}
+	if q != "" {
+		query.Set("q", q)
+	}
+	if page > 0 {
+		query.Set("page", strconv.Itoa(page))
+	}
+	if size > 0 {
+		query.Set("size", strconv.Itoa(size))
+	} else {
+		query.Set("size", "100")
+	}
+
+	var result model.LicenseSearchResult
+	if err := c.Get("/licenses/", query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/api/licenses_test.go
+++ b/internal/api/licenses_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestSearchLicenses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/licenses/" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.LicenseSearchResult{
+			Hits: model.LicenseHits{
+				Hits:  []model.License{{ID: "cc-by-4.0", Title: "Creative Commons Attribution 4.0"}},
+				Total: 1,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	result, err := client.SearchLicenses("creative commons", 0, 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if result.Hits.Hits[0].ID != "cc-by-4.0" {
+		t.Errorf("id = %q", result.Hits.Hits[0].ID)
+	}
+}


### PR DESCRIPTION
## ELI5

Same idea as the records API (#9), but for the other Zenodo endpoints: searching communities (groups/organizations on Zenodo), searching available licenses (CC-BY, MIT, etc.), and listing share links for a record. These are the API calls that the CLI commands in Issues #11 and #12 will use.

## Summary

- `SearchCommunities()`: search/list communities with pagination
- `SearchLicenses()`: search available licenses with pagination
- `ListAccessLinks()`: list share links for a record
- 3 tests with httptest mock server

## Code changes

| File | What |
|------|------|
| `internal/api/communities.go` | `SearchCommunities()` |
| `internal/api/licenses.go` | `SearchLicenses()` |
| `internal/api/access.go` | `ListAccessLinks()` |
| `internal/api/*_test.go` | 3 tests |

## Test plan

- [x] `go test ./...` — all 54 tests pass
- [x] `go build ./...` compiles

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)