### PR TITLE
Implement communities, licenses, and access links CLI commands

### DIFF
--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ran-codes/zenodo-cli/internal/api"
+	"github.com/ran-codes/zenodo-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var accessCmd = &cobra.Command{
+	Use:   "access",
+	Short: "Manage access links",
+}
+
+var accessLinksCmd = &cobra.Command{
+	Use:   "links",
+	Short: "Manage share links for records",
+}
+
+var accessLinksListCmd = &cobra.Command{
+	Use:   "list <record-id>",
+	Short: "List share links for a record",
+	Long: `List all share/access links for a record.
+
+Examples:
+  zenodo access links list 12345
+  zenodo access links list 12345 --output json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid record ID: %s", args[0])
+		}
+
+		client := api.NewClient(appCtx.BaseURL, appCtx.Token)
+		links, err := client.ListAccessLinks(id)
+		if err != nil {
+			return err
+		}
+		return output.Format(os.Stdout, links, appCtx.Output, appCtx.Fields)
+	},
+}
+
+func init() {
+	accessLinksCmd.AddCommand(accessLinksListCmd)
+	accessCmd.AddCommand(accessLinksCmd)
+	rootCmd.AddCommand(accessCmd)
+}

--- a/internal/cli/communities.go
+++ b/internal/cli/communities.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/ran-codes/zenodo-cli/internal/api"
+	"github.com/ran-codes/zenodo-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var communitiesCmd = &cobra.Command{
+	Use:   "communities",
+	Short: "Search and list communities",
+}
+
+var communitiesListCmd = &cobra.Command{
+	Use:   "list [query]",
+	Short: "List or search communities",
+	Long: `List or search Zenodo communities.
+
+Examples:
+  zenodo communities list
+  zenodo communities list "open science"
+  zenodo communities list --output csv`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := api.NewClient(appCtx.BaseURL, appCtx.Token)
+
+		q := ""
+		if len(args) > 0 {
+			q = args[0]
+		}
+
+		result, err := client.SearchCommunities(q, 0, 0)
+		if err != nil {
+			return err
+		}
+		return output.Format(os.Stdout, result.Hits.Hits, appCtx.Output, appCtx.Fields)
+	},
+}
+
+func init() {
+	communitiesCmd.AddCommand(communitiesListCmd)
+	rootCmd.AddCommand(communitiesCmd)
+}

--- a/internal/cli/licenses.go
+++ b/internal/cli/licenses.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/ran-codes/zenodo-cli/internal/api"
+	"github.com/ran-codes/zenodo-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var licensesCmd = &cobra.Command{
+	Use:   "licenses",
+	Short: "Search available licenses",
+}
+
+var licensesSearchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search available licenses",
+	Long: `Search Zenodo's available licenses.
+
+Examples:
+  zenodo licenses search
+  zenodo licenses search "creative commons"
+  zenodo licenses search "MIT" --output json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := api.NewClient(appCtx.BaseURL, appCtx.Token)
+
+		q := ""
+		if len(args) > 0 {
+			q = args[0]
+		}
+
+		result, err := client.SearchLicenses(q, 0, 0)
+		if err != nil {
+			return err
+		}
+		return output.Format(os.Stdout, result.Hits.Hits, appCtx.Output, appCtx.Fields)
+	},
+}
+
+func init() {
+	licensesCmd.AddCommand(licensesSearchCmd)
+	rootCmd.AddCommand(licensesCmd)
+}


### PR DESCRIPTION
## ELI5

Now you can browse Zenodo communities ("what groups/organizations exist?"), search licenses ("what license should I pick for my dataset?"), and list share links for a record. These are the last three read-only commands, completing Phase 2's user-facing CLI.

## Summary

- `zenodo communities list [query]` — search/list Zenodo communities
- `zenodo licenses search [query]` — search available licenses
- `zenodo access links list <id>` — list share links for a record
- All respect `--output` and `--fields` flags

## Code changes

| File | What |
|------|------|
| `internal/cli/communities.go` | `communities list` command |
| `internal/cli/licenses.go` | `licenses search` command |
| `internal/cli/access.go` | `access links list` command |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` — all 54 tests pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)