### PR TITLE
Implement depositions API methods (get, update, edit, publish, discard)

### DIFF
--- a/internal/api/depositions.go
+++ b/internal/api/depositions.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+// GetDeposition retrieves a deposition by ID.
+func (c *Client) GetDeposition(id int) (*model.Deposition, error) {
+	var result model.Deposition
+	if err := c.Get(fmt.Sprintf("/deposit/depositions/%d", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateDeposition updates the metadata of a deposition (full replacement PUT).
+func (c *Client) UpdateDeposition(id int, metadata model.Metadata) (*model.Deposition, error) {
+	body := map[string]interface{}{
+		"metadata": metadata,
+	}
+	var result model.Deposition
+	if err := c.Put(fmt.Sprintf("/deposit/depositions/%d", id), body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// EditDeposition unlocks a published record for editing.
+func (c *Client) EditDeposition(id int) (*model.Deposition, error) {
+	var result model.Deposition
+	if err := c.Post(fmt.Sprintf("/deposit/depositions/%d/actions/edit", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// PublishDeposition publishes (or re-publishes) a deposition.
+func (c *Client) PublishDeposition(id int) (*model.Deposition, error) {
+	var result model.Deposition
+	if err := c.Post(fmt.Sprintf("/deposit/depositions/%d/actions/publish", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DiscardDeposition discards changes on an unpublished deposition.
+func (c *Client) DiscardDeposition(id int) (*model.Deposition, error) {
+	var result model.Deposition
+	if err := c.Post(fmt.Sprintf("/deposit/depositions/%d/actions/discard", id), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/api/depositions_test.go
+++ b/internal/api/depositions_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/model"
+)
+
+func TestGetDeposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/deposit/depositions/100" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.Deposition{
+			ID:       100,
+			Metadata: model.Metadata{Title: "Test Deposition"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	dep, err := client.GetDeposition(100)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if dep.ID != 100 || dep.Metadata.Title != "Test Deposition" {
+		t.Errorf("unexpected deposition: %+v", dep)
+	}
+}
+
+func TestUpdateDeposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/deposit/depositions/100" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]model.Metadata
+		json.Unmarshal(body, &payload)
+		if payload["metadata"].Title != "Updated Title" {
+			t.Errorf("title = %q", payload["metadata"].Title)
+		}
+		json.NewEncoder(w).Encode(model.Deposition{
+			ID:       100,
+			Metadata: model.Metadata{Title: "Updated Title"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	dep, err := client.UpdateDeposition(100, model.Metadata{Title: "Updated Title"})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if dep.Metadata.Title != "Updated Title" {
+		t.Errorf("title = %q", dep.Metadata.Title)
+	}
+}
+
+func TestEditDeposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/deposit/depositions/100/actions/edit" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.Deposition{ID: 100, State: "inprogress"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	dep, err := client.EditDeposition(100)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if dep.State != "inprogress" {
+		t.Errorf("state = %q", dep.State)
+	}
+}
+
+func TestPublishDeposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/deposit/depositions/100/actions/publish" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.Deposition{ID: 100, State: "done"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	dep, err := client.PublishDeposition(100)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if dep.State != "done" {
+		t.Errorf("state = %q", dep.State)
+	}
+}
+
+func TestDiscardDeposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/deposit/depositions/100/actions/discard" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(model.Deposition{ID: 100, State: "done"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "tok")
+	dep, err := client.DiscardDeposition(100)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if dep.ID != 100 {
+		t.Errorf("id = %d", dep.ID)
+	}
+}


### PR DESCRIPTION
## ELI5

When you want to edit a published Zenodo record, there's a specific dance: unlock it for editing, update the metadata, then republish. This PR adds the API methods for each step of that dance — get the current deposition, update its metadata (PUT), unlock it, publish it, or throw away your changes. These are the building blocks the deposit CLI commands (#16) will use.

## Summary

- 5 API methods matching Zenodo's deposition endpoints
- UpdateDeposition wraps metadata in `{"metadata": ...}` as Zenodo expects
- 5 tests with httptest verifying method, path, body, and response parsing

## Code changes

| File | What |
|------|------|
| `internal/api/depositions.go` | `GetDeposition`, `UpdateDeposition`, `EditDeposition`, `PublishDeposition`, `DiscardDeposition` |
| `internal/api/depositions_test.go` | 5 tests |

## Test plan

- [x] `go test ./...` — all 59 tests pass
- [x] `go build ./...` compiles

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)