### PR TITLE
Add shell completions and version flag with build info

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for the zenodo CLI.
+
+To load completions:
+
+  Bash:
+    $ source <(zenodo completion bash)
+    # To load completions for each session, execute once:
+    # Linux:
+    $ zenodo completion bash > /etc/bash_completion.d/zenodo
+    # macOS:
+    $ zenodo completion bash > $(brew --prefix)/etc/bash_completion.d/zenodo
+
+  Zsh:
+    $ source <(zenodo completion zsh)
+    # To load completions for each session, execute once:
+    $ zenodo completion zsh > "${fpath[1]}/_zenodo"
+
+  Fish:
+    $ zenodo completion fish | source
+    # To load completions for each session, execute once:
+    $ zenodo completion fish > ~/.config/fish/completions/zenodo.fish
+
+  PowerShell:
+    PS> zenodo completion powershell | Out-String | Invoke-Expression
+    # To load completions for every new session, add the output to your profile.`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Build info set via -ldflags at build time.
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version and build information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("zenodo %s\n", version)
+		fmt.Printf("  commit: %s\n", commit)
+		fmt.Printf("  built:  %s\n", date)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## ELI5

Two quality-of-life features: (1) tab completion — type `zenodo rec<TAB>` and it fills in `records` for bash/zsh/fish/powershell, and (2) `zenodo version` shows the version number, git commit, and build date. The version info gets baked in at build time via Go's `-ldflags`, so `goreleaser` (#18) will inject the real values automatically.

## Summary

- `zenodo completion [bash|zsh|fish|powershell]` generates shell completion scripts
- `zenodo version` prints version, commit hash, build date
- Version/commit/date set via `-ldflags` at build time (defaults to "dev"/"unknown")

## Code changes

| File | What |
|------|------|
| `internal/cli/completion.go` | Completion command for 4 shells |
| `internal/cli/version.go` | Version command with ldflags vars |

## Test plan

- [x] `go test ./...` — all 75 tests pass
- [x] `zenodo version` prints "dev" (default)
- [x] `go build -ldflags "-X ...version=0.1.0"` then `zenodo version` prints "0.1.0"
- [x] `zenodo completion bash` generates valid completion script

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)