### PR TITLE
Configure goreleaser for cross-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - main: ./cmd/zenodo
+    binary: zenodo
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/ran-codes/zenodo-cli/internal/cli.version={{.Version}}
+      - -X github.com/ran-codes/zenodo-cli/internal/cli.commit={{.Commit}}
+      - -X github.com/ran-codes/zenodo-cli/internal/cli.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"


### PR DESCRIPTION
## ELI5

When you want to release a new version, you just tag it (`git tag v0.1.0 && git push --tags`) and GitHub Actions automatically builds binaries for Windows, macOS, and Linux (both Intel and ARM), injects the version info, and creates a GitHub Release with downloadable archives. No manual build steps needed.

## Summary

- `.goreleaser.yaml`: cross-platform build config for 6 targets (3 OS x 2 arch)
- Static binaries (CGO_ENABLED=0), stripped symbols for smaller size
- Version/commit/date injected via ldflags
- tar.gz for unix, zip for windows
- `.github/workflows/release.yml`: triggers on `v*` tags, runs goreleaser

## Code changes

| File | What |
|------|------|
| `.goreleaser.yaml` | Build matrix, archive formats, ldflags, changelog config |
| `.github/workflows/release.yml` | GitHub Actions workflow for automated releases |

## Test plan

- [x] `go build ./...` compiles
- [x] Config follows goreleaser v2 schema

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)