### PR TITLE
Integration tests against Zenodo sandbox

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,25 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 6am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ran-codes/zenodo-cli'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Run integration tests
+        env:
+          ZENODO_SANDBOX_TOKEN: ${{ secrets.ZENODO_SANDBOX_TOKEN }}
+        run: go test ./test/integration/ -tags=integration -v -timeout 120s

--- a/test/integration/records_test.go
+++ b/test/integration/records_test.go
@@ -1,0 +1,59 @@
+// Package integration contains integration tests that run against the Zenodo sandbox.
+// These tests require a ZENODO_SANDBOX_TOKEN environment variable to be set.
+// Run with: go test ./test/integration/ -tags=integration -v
+//
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ran-codes/zenodo-cli/internal/api"
+)
+
+func sandboxClient(t *testing.T) *api.Client {
+	t.Helper()
+	token := os.Getenv("ZENODO_SANDBOX_TOKEN")
+	if token == "" {
+		t.Skip("ZENODO_SANDBOX_TOKEN not set, skipping integration test")
+	}
+	return api.NewClient("https://sandbox.zenodo.org/api", token)
+}
+
+func TestIntegration_SearchRecords(t *testing.T) {
+	client := sandboxClient(t)
+
+	result, err := client.SearchRecords("test", api.RecordListParams{Size: 5})
+	if err != nil {
+		t.Fatalf("SearchRecords error: %v", err)
+	}
+	if result.Hits.Total < 0 {
+		t.Error("expected non-negative total")
+	}
+	t.Logf("Found %d total records (showing %d)", result.Hits.Total, len(result.Hits.Hits))
+}
+
+func TestIntegration_SearchCommunities(t *testing.T) {
+	client := sandboxClient(t)
+
+	result, err := client.SearchCommunities("", 1, 5)
+	if err != nil {
+		t.Fatalf("SearchCommunities error: %v", err)
+	}
+	t.Logf("Found %d communities", result.Hits.Total)
+}
+
+func TestIntegration_SearchLicenses(t *testing.T) {
+	client := sandboxClient(t)
+
+	result, err := client.SearchLicenses("creative commons", 1, 5)
+	if err != nil {
+		t.Fatalf("SearchLicenses error: %v", err)
+	}
+	if result.Hits.Total == 0 {
+		t.Error("expected at least one license matching 'creative commons'")
+	}
+	t.Logf("Found %d licenses", result.Hits.Total)
+}


### PR DESCRIPTION
## ELI5

Unit tests use fake HTTP servers, but you also want to occasionally test against the real Zenodo sandbox to make sure nothing's drifted. These tests do that — they call the actual sandbox API to search records, communities, and licenses. They only run when you have a sandbox token set, and there's a GitHub Action to run them weekly or on-demand.

## Summary

- Integration tests for records, communities, and licenses search
- Build-tagged `integration` so they don't run in normal `go test`
- Gracefully skip when `ZENODO_SANDBOX_TOKEN` is not set
- GitHub Actions workflow with manual dispatch + weekly schedule

## Code changes

| File | What |
|------|------|
| `test/integration/records_test.go` | 3 integration tests |
| `.github/workflows/integration.yml` | CI workflow for integration tests |

## Test plan

- [x] `go test ./...` — all 75 unit tests pass (integration tests excluded)
- [x] `go build ./...` compiles

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)