### PR TITLE
Fix API response models to match real Zenodo API

### DIFF
--- a/internal/api/access.go
+++ b/internal/api/access.go
@@ -9,8 +9,8 @@ import (
 // ListAccessLinks returns the share/access links for a record.
 func (c *Client) ListAccessLinks(recordID int) ([]model.AccessLink, error) {
 	var result model.AccessLinkList
-	if err := c.Get(fmt.Sprintf("/api/records/%d/access/links", recordID), nil, &result); err != nil {
+	if err := c.Get(fmt.Sprintf("/records/%d/access/links", recordID), nil, &result); err != nil {
 		return nil, err
 	}
-	return result.Hits, nil
+	return result.Hits.Hits, nil
 }

--- a/internal/api/access_test.go
+++ b/internal/api/access_test.go
@@ -11,11 +11,14 @@ import (
 
 func TestListAccessLinks(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/records/123/access/links" {
+		if r.URL.Path != "/records/123/access/links" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(model.AccessLinkList{
-			Hits: []model.AccessLink{{ID: "link-1"}},
+			Hits: model.AccessLinkHits{
+				Hits: []model.AccessLink{{ID: "link-1"}},
+				Total: 1,
+			},
 		})
 	}))
 	defer srv.Close()

--- a/internal/api/communities.go
+++ b/internal/api/communities.go
@@ -23,7 +23,7 @@ func (c *Client) SearchCommunities(q string, page, size int) (*model.CommunitySe
 	}
 
 	var result model.CommunitySearchResult
-	if err := c.Get("/communities/", query, &result); err != nil {
+	if err := c.Get("/communities", query, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/api/communities_test.go
+++ b/internal/api/communities_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSearchCommunities(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/communities/" {
+		if r.URL.Path != "/communities" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		if r.URL.Query().Get("q") != "open science" {
@@ -19,7 +19,7 @@ func TestSearchCommunities(t *testing.T) {
 		}
 		json.NewEncoder(w).Encode(model.CommunitySearchResult{
 			Hits: model.CommunityHits{
-				Hits:  []model.Community{{ID: "open-sci", Title: "Open Science"}},
+				Hits:  []model.Community{{ID: "open-sci", Metadata: model.CommunityMetadata{Title: "Open Science"}}},
 				Total: 1,
 			},
 		})

--- a/internal/api/licenses.go
+++ b/internal/api/licenses.go
@@ -23,7 +23,7 @@ func (c *Client) SearchLicenses(q string, page, size int) (*model.LicenseSearchR
 	}
 
 	var result model.LicenseSearchResult
-	if err := c.Get("/licenses/", query, &result); err != nil {
+	if err := c.Get("/licenses", query, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/api/licenses_test.go
+++ b/internal/api/licenses_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestSearchLicenses(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/licenses/" {
+		if r.URL.Path != "/licenses" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(model.LicenseSearchResult{
 			Hits: model.LicenseHits{
-				Hits:  []model.License{{ID: "cc-by-4.0", Title: "Creative Commons Attribution 4.0"}},
+				Hits:  []model.License{{ID: "cc-by-4.0", Title: map[string]string{"en": "Creative Commons Attribution 4.0"}}},
 				Total: 1,
 			},
 		})

--- a/internal/api/records.go
+++ b/internal/api/records.go
@@ -12,7 +12,7 @@ import (
 func (c *Client) ListUserRecords(params RecordListParams) (*model.RecordSearchResult, error) {
 	query := params.toQuery()
 	var result model.RecordSearchResult
-	if err := c.Get("/api/records", query, &result); err != nil {
+	if err := c.Get("/records", query, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -25,7 +25,7 @@ func (c *Client) SearchRecords(q string, params RecordListParams) (*model.Record
 		query.Set("q", q)
 	}
 	var result model.RecordSearchResult
-	if err := c.Get("/records/", query, &result); err != nil {
+	if err := c.Get("/records", query, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -43,7 +43,7 @@ func (c *Client) GetRecord(id int) (*model.Record, error) {
 // ListVersions returns all versions of a record.
 func (c *Client) ListVersions(id int) (*model.RecordSearchResult, error) {
 	var result model.RecordSearchResult
-	if err := c.Get(fmt.Sprintf("/api/records/%d/versions", id), nil, &result); err != nil {
+	if err := c.Get(fmt.Sprintf("/records/%d/versions", id), nil, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/internal/api/records_test.go
+++ b/internal/api/records_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSearchRecords(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/records/" {
+		if r.URL.Path != "/records" {
 			t.Errorf("path = %q, want /records/", r.URL.Path)
 		}
 		if r.URL.Query().Get("q") != "climate" {
@@ -63,8 +63,8 @@ func TestGetRecord(t *testing.T) {
 
 func TestListUserRecords(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/records" {
-			t.Errorf("path = %q, want /api/records", r.URL.Path)
+		if r.URL.Path != "/records" {
+			t.Errorf("path = %q, want /records", r.URL.Path)
 		}
 		if r.URL.Query().Get("status") != "draft" {
 			t.Errorf("status = %q, want draft", r.URL.Query().Get("status"))
@@ -90,7 +90,7 @@ func TestListUserRecords(t *testing.T) {
 
 func TestListVersions(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/records/100/versions" {
+		if r.URL.Path != "/records/100/versions" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(model.RecordSearchResult{

--- a/internal/model/access.go
+++ b/internal/model/access.go
@@ -12,5 +12,11 @@ type AccessLink struct {
 
 // AccessLinkList is the response from the access links endpoint.
 type AccessLinkList struct {
-	Hits []AccessLink `json:"hits"`
+	Hits AccessLinkHits `json:"hits"`
+}
+
+// AccessLinkHits contains access link results.
+type AccessLinkHits struct {
+	Hits  []AccessLink `json:"hits"`
+	Total int          `json:"total"`
 }

--- a/internal/model/community.go
+++ b/internal/model/community.go
@@ -4,15 +4,20 @@ import "time"
 
 // Community represents a Zenodo community.
 type Community struct {
-	ID          string    `json:"id"`
-	Title       string    `json:"title"`
-	Description string    `json:"description,omitempty"`
-	PageURL     string    `json:"page,omitempty"`
+	ID       string            `json:"id"`
+	Slug     string            `json:"slug,omitempty"`
+	Metadata CommunityMetadata `json:"metadata,omitempty"`
+	Created  time.Time         `json:"created"`
+	Updated  time.Time         `json:"updated"`
+	Links    Links             `json:"links,omitempty"`
+}
+
+// CommunityMetadata contains the community's metadata fields.
+type CommunityMetadata struct {
+	Title          string `json:"title,omitempty"`
+	Description    string `json:"description,omitempty"`
 	CurationPolicy string `json:"curation_policy,omitempty"`
-	LogoURL     string    `json:"logo_url,omitempty"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
-	Links       Links     `json:"links,omitempty"`
+	Website        string `json:"website,omitempty"`
 }
 
 // CommunitySearchResult is the paginated response from communities search.

--- a/internal/model/license.go
+++ b/internal/model/license.go
@@ -2,16 +2,28 @@ package model
 
 // License represents a Zenodo license.
 type License struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
+	ID    string            `json:"id"`
+	Title map[string]string `json:"title,omitempty"`
+	Props LicenseProps      `json:"props,omitempty"`
+	Tags  []string          `json:"tags,omitempty"`
+}
+
+// LicenseProps contains extra properties for a license.
+type LicenseProps struct {
 	URL         string `json:"url,omitempty"`
-	Family      string `json:"family,omitempty"`
-	Domain      string `json:"domain_content,omitempty"`
-	DomainData  string `json:"domain_data,omitempty"`
-	DomainSW    string `json:"domain_software,omitempty"`
-	Maintainer  string `json:"maintainer,omitempty"`
-	ODConformance string `json:"od_conformance,omitempty"`
-	OSIApproved bool   `json:"osi_approved,omitempty"`
+	Scheme      string `json:"scheme,omitempty"`
+	OSIApproved string `json:"osi_approved,omitempty"`
+}
+
+// TitleString returns the English title, falling back to the first available.
+func (l *License) TitleString() string {
+	if t, ok := l.Title["en"]; ok {
+		return t
+	}
+	for _, t := range l.Title {
+		return t
+	}
+	return ""
 }
 
 // LicenseSearchResult is the paginated response from licenses search.

--- a/internal/validate/metadata.go
+++ b/internal/validate/metadata.go
@@ -61,7 +61,7 @@ func Metadata(m model.Metadata) []string {
 		}
 
 		// License required for open/embargoed.
-		if (m.AccessRight == "open" || m.AccessRight == "embargoed") && m.License == "" {
+		if (m.AccessRight == "open" || m.AccessRight == "embargoed") && m.LicenseString() == "" {
 			errs = append(errs, "license is required when access_right is open or embargoed")
 		}
 

--- a/internal/validate/metadata_test.go
+++ b/internal/validate/metadata_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -14,7 +15,7 @@ func validMetadata() model.Metadata {
 		UploadType:      "dataset",
 		PublicationDate: "2024-01-01",
 		AccessRight:     "open",
-		License:         "cc-by-4.0",
+		License:         json.RawMessage(`"cc-by-4.0"`),
 		Creators:        []model.Creator{{Name: "Test Author"}},
 	}
 }
@@ -74,7 +75,7 @@ func TestCreatorMissingName(t *testing.T) {
 func TestMissingLicenseForOpen(t *testing.T) {
 	m := validMetadata()
 	m.AccessRight = "open"
-	m.License = ""
+	m.License = nil
 	errs := Metadata(m)
 	if !containsError(errs, "license is required") {
 		t.Errorf("expected license error, got: %v", errs)
@@ -84,7 +85,7 @@ func TestMissingLicenseForOpen(t *testing.T) {
 func TestMissingEmbargoDate(t *testing.T) {
 	m := validMetadata()
 	m.AccessRight = "embargoed"
-	m.License = "cc-by-4.0"
+	m.License = json.RawMessage(`"cc-by-4.0"`)
 	m.EmbargoDate = ""
 	errs := Metadata(m)
 	if !containsError(errs, "embargo_date") {
@@ -95,7 +96,7 @@ func TestMissingEmbargoDate(t *testing.T) {
 func TestMissingAccessConditions(t *testing.T) {
 	m := validMetadata()
 	m.AccessRight = "restricted"
-	m.License = ""
+	m.License = nil
 	m.AccessConditions = ""
 	errs := Metadata(m)
 	if !containsError(errs, "access_conditions") {
@@ -106,7 +107,7 @@ func TestMissingAccessConditions(t *testing.T) {
 func TestClosedAccessNoLicenseRequired(t *testing.T) {
 	m := validMetadata()
 	m.AccessRight = "closed"
-	m.License = ""
+	m.License = nil
 	errs := Metadata(m)
 	if containsError(errs, "license") {
 		t.Errorf("license should not be required for closed access, got: %v", errs)


### PR DESCRIPTION
## ELI5

Our code expected the Zenodo API to return data in one shape, but the real API returns it in a different shape. Like expecting a phone number as just digits but getting it with dashes and country code. This fixes all the mismatches found during user testing so every read command actually works against the real Zenodo API.

## Summary
- **Double `/api` prefix**: Base URL is `https://zenodo.org/api` but some paths had `/api/records` making it `/api/api/records` → 404
- **Trailing slashes**: `/communities/`, `/licenses/`, `/records/` all return 404; removed trailing slashes
- **`license` field**: API returns `{"id": "cc-by-4.0"}` (object), not `"cc-by-4.0"` (string) → changed to `json.RawMessage` with helper
- **`resource_type` field**: API returns `{"title": "Other", "type": "publication"}` → added `ResourceType` struct
- **Community model**: API nests title/description under `metadata` object with a `slug` field
- **License model**: API returns localized titles `{"en": "Creative Commons..."}` → changed to `map[string]string`
- **Access links**: API returns `{"hits": {"hits": [...]}}` not `{"hits": [...]}` → added nested struct
- **`conceptrecid`**: API returns as string, not int

## Test plan
- [x] All 75 unit tests pass
- [x] `records list` — returns results from production API
- [x] `records search "test"` — returns results
- [x] `records get 16422653` — returns full record JSON
- [x] `records versions 16422653` — returns 3 versions
- [x] `communities list` — returns communities
- [x] `licenses search "creative commons"` — returns 38 licenses
- [x] Output formats: `-o json`, `-o table`, `-o csv` all work
- [x] `--fields id,title,doi` field selection works
- [x] `--sandbox` flag correctly switches base URL
- [x] `config get`, `config profiles`, `version`, `completion bash/zsh` all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)