### PR TITLE
Fix records list: IPv4, correct endpoint, concise table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,5 +9,6 @@
 - Open a PR describing what changed and why.
   - Include an ELI5 section in PR descriptions.
 - Ask for review before merging and open the PR in chrome window. Only merge after explicit approval.
+- After code changes, rebuild the binary with `go build -o zenodo.exe ./cmd/zenodo` so `./zenodo.exe` reflects the latest code.
 - Run `go build ./...` and `go test ./...` before pushing.
 - See `.claude/reference/v0.1/DEVELOP.md` for project structure and build instructions.

--- a/internal/api/records.go
+++ b/internal/api/records.go
@@ -8,14 +8,15 @@ import (
 	"github.com/ran-codes/zenodo-cli/internal/model"
 )
 
-// ListUserRecords returns the authenticated user's records and drafts.
-func (c *Client) ListUserRecords(params RecordListParams) (*model.RecordSearchResult, error) {
+// ListUserRecords returns the authenticated user's records and drafts
+// via the /deposit/depositions endpoint.
+func (c *Client) ListUserRecords(params RecordListParams) ([]model.Deposition, error) {
 	query := params.toQuery()
-	var result model.RecordSearchResult
-	if err := c.Get("/records", query, &result); err != nil {
+	var result []model.Deposition
+	if err := c.Get("/deposit/depositions", query, &result); err != nil {
 		return nil, err
 	}
-	return &result, nil
+	return result, nil
 }
 
 // SearchRecords searches published records with an Elasticsearch query.

--- a/internal/api/records_test.go
+++ b/internal/api/records_test.go
@@ -63,18 +63,13 @@ func TestGetRecord(t *testing.T) {
 
 func TestListUserRecords(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/records" {
-			t.Errorf("path = %q, want /records", r.URL.Path)
+		if r.URL.Path != "/deposit/depositions" {
+			t.Errorf("path = %q, want /deposit/depositions", r.URL.Path)
 		}
 		if r.URL.Query().Get("status") != "draft" {
 			t.Errorf("status = %q, want draft", r.URL.Query().Get("status"))
 		}
-		json.NewEncoder(w).Encode(model.RecordSearchResult{
-			Hits: model.RecordHits{
-				Hits:  []model.Record{{ID: 1}},
-				Total: 1,
-			},
-		})
+		json.NewEncoder(w).Encode([]model.Deposition{{ID: 1, Title: "Draft Record"}})
 	}))
 	defer srv.Close()
 
@@ -83,8 +78,11 @@ func TestListUserRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListUserRecords() error: %v", err)
 	}
-	if result.Hits.Total != 1 {
-		t.Errorf("total = %d, want 1", result.Hits.Total)
+	if len(result) != 1 {
+		t.Errorf("count = %d, want 1", len(result))
+	}
+	if result[0].Title != "Draft Record" {
+		t.Errorf("title = %q, want Draft Record", result[0].Title)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three fixes for `./zenodo.exe records list`:

- **Force IPv4 in HTTP client** — Avoids 30s timeouts on networks with broken IPv6 connectivity by dialing `tcp4` explicitly.
- **Use correct API endpoint** — `ListUserRecords` now hits `/deposit/depositions` (user's own records/drafts) instead of `/records` (public search across all of Zenodo).
- **Concise default table output** — Default columns are now `title, communities, doi_url, created` instead of dumping every JSON field (metadata, links, etc.). Single-key object arrays like `[{"identifier":"my-org"}]` are flattened to `my-org`. Users can still override with `--fields`.

Also adds build instruction to CLAUDE.md (`go build -o zenodo.exe ./cmd/zenodo`).

---

## IPv4 Bug

### ELI5

Imagine you're trying to call someone and your phone tries a broken line first every time. It waits 30 seconds, gives up, then tries the working line. We told it to just use the working line from the start.

### Problem

Go's default HTTP client tries IPv6 first when connecting. On networks where IPv6 is advertised but broken (common on Windows/MSYS), every API request to `zenodo.org` hung for 30 seconds waiting for the IPv6 connection to time out before falling back to IPv4.

### Solution

Force the HTTP transport to dial `tcp4` (IPv4 only) in `internal/api/client.go`, bypassing the broken IPv6 path entirely. Also set explicit dial and keepalive timeouts.

---

## Wrong Endpoint Bug

### ELI5

Instead of asking "show me MY stuff," the CLI was asking "show me EVERYTHING on Zenodo." That's millions of records.

### Problem

`ListUserRecords` called `/records` (the public search endpoint for all of Zenodo) instead of `/deposit/depositions` (the authenticated endpoint for the current user's records and drafts).

### Solution

Changed the endpoint to `/deposit/depositions` and updated the return type to `[]model.Deposition` to match the API response shape.

---

## Verbose Table Bug

### ELI5

The table was printing every single piece of information about each record — like printing someone's entire medical history when you just wanted their name and phone number.

### Problem

When no `--fields` flag was provided, the table formatter dumped every field from the JSON response — including deeply nested `metadata` (with description, creators, keywords, etc.) and `links` (10+ URLs). This produced a 5000+ line table for just 6 records.

### Solution

Set default fields for list commands: `title, communities, doi_url, created`. Added array flattening in `stringify()` so `[{"identifier":"my-org"}]` renders as `my-org` instead of raw JSON. Users can still override with `--fields` for any columns they want.

---

## Test plan

- [ ] Run `./zenodo.exe records list` — should return quickly with a concise table
- [ ] Run `./zenodo.exe records list --fields id,title,doi_url` — custom fields still work
- [ ] Run `./zenodo.exe records list --output json` — JSON output still includes all fields
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)