### PR TITLE
chore: disable deposit write commands for v0.1

### DIFF
--- a/internal/api/depositions.go
+++ b/internal/api/depositions.go
@@ -15,6 +15,10 @@ func (c *Client) GetDeposition(id int) (*model.Deposition, error) {
 	return &result, nil
 }
 
+// v0.1: Write methods disabled — read-only release.
+// They will be re-enabled in a future version.
+
+/*
 // UpdateDeposition updates the metadata of a deposition (full replacement PUT).
 func (c *Client) UpdateDeposition(id int, metadata model.Metadata) (*model.Deposition, error) {
 	body := map[string]interface{}{
@@ -53,3 +57,4 @@ func (c *Client) DiscardDeposition(id int) (*model.Deposition, error) {
 	}
 	return &result, nil
 }
+*/

--- a/internal/api/depositions_test.go
+++ b/internal/api/depositions_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,6 +31,9 @@ func TestGetDeposition(t *testing.T) {
 	}
 }
 
+// v0.1: Write method tests disabled — read-only release.
+
+/*
 func TestUpdateDeposition(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/deposit/depositions/100" {
@@ -116,3 +118,4 @@ func TestDiscardDeposition(t *testing.T) {
 		t.Errorf("id = %d", dep.ID)
 	}
 }
+*/

--- a/internal/cli/deposit.go
+++ b/internal/cli/deposit.go
@@ -1,5 +1,10 @@
 package cli
 
+// v0.1: Deposit write commands disabled — read-only release.
+// All deposit subcommands (edit, update, discard, publish) are write operations.
+// They will be re-enabled in a future version.
+
+/*
 import (
 	"bufio"
 	"encoding/json"
@@ -292,3 +297,4 @@ func confirm(prompt string) bool {
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	return answer == "y" || answer == "yes"
 }
+*/


### PR DESCRIPTION
## Summary
- Comment out all deposit write subcommands (`edit`, `update`, `discard`, `publish`) and their CLI registration
- Comment out corresponding write API methods (`UpdateDeposition`, `EditDeposition`, `PublishDeposition`, `DiscardDeposition`) keeping only `GetDeposition`
- Comment out write method tests

## ELI5
v0.1 is a read-only release — you can look at records but not change them. This wraps all the "change stuff" code in comments so it's still there for later but won't run. Will add write to later relaes

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `zenodo.exe` built locally
- [ ] Verify `zenodo deposit` is no longer a recognized command

🤖 Generated with [Claude Code](https://claude.com/claude-code)