### PR TITLE
chore: disable access links for v0.1

### DIFF
--- a/.claude/reference/v0.1/DEVELOP.md
+++ b/.claude/reference/v0.1/DEVELOP.md
@@ -67,7 +67,7 @@ internal/
     records.go              records list/search/get/versions commands
     communities.go          communities list command
     licenses.go             licenses search command
-    access.go               access links list command
+    access.go               access links list command (disabled v0.1)
     deposit.go              deposit edit/update/discard/publish commands
     completion.go           Shell completion generation
     version.go              Version command (ldflags-injected)
@@ -77,7 +77,7 @@ internal/
     records.go              Records API methods
     communities.go          Communities API methods
     licenses.go             Licenses API methods
-    access.go               Access links API methods
+    access.go               Access links API methods (disabled v0.1)
     depositions.go          Depositions API methods (edit/update/publish/discard)
   config/
     config.go               Viper-backed config with profiles
@@ -87,7 +87,7 @@ internal/
     record.go               Record, Deposition, Metadata structs
     community.go            Community structs
     license.go              License structs
-    access.go               Access link structs
+    access.go               Access link structs (unused v0.1)
     stats.go                Stats struct
     error.go                APIError with hints
   output/

--- a/.claude/reference/v0.1/PLAN.md
+++ b/.claude/reference/v0.1/PLAN.md
@@ -30,7 +30,7 @@ zenodo-cli/
 │   │   ├── deposit.go              # deposit edit/update/discard/publish commands
 │   │   ├── communities.go          # communities list command
 │   │   ├── licenses.go             # licenses search command
-│   │   └── access.go               # access links list command
+│   │   └── access.go               # access links list command (disabled v0.1)
 │   ├── api/
 │   │   ├── client.go               # HTTP client with auth, rate limiting, base URL
 │   │   ├── ratelimit.go            # Rate limiter (token bucket + header parsing)
@@ -38,7 +38,7 @@ zenodo-cli/
 │   │   ├── depositions.go          # Depositions API methods
 │   │   ├── communities.go          # Communities API methods
 │   │   ├── licenses.go             # Licenses API methods
-│   │   └── access.go               # Access links API methods
+│   │   └── access.go               # Access links API methods (disabled v0.1)
 │   ├── config/
 │   │   ├── config.go               # Config loading (viper), profile management
 │   │   ├── keyring.go              # Keyring get/set/delete/migrate
@@ -110,7 +110,7 @@ zenodo-cli/
    - `api/records.go` — `ListUserRecords()`, `SearchRecords()`, `GetRecord()`, `ListVersions()`
    - `api/communities.go` — `SearchCommunities()`
    - `api/licenses.go` — `SearchLicenses()`
-   - `api/access.go` — `ListAccessLinks()`
+   - ~~`api/access.go` — `ListAccessLinks()`~~ *(disabled v0.1)*
 5. Implement CLI commands:
    - `records list` (with `--status`, `--community`, `--all` pagination)
    - `records search <query>` (with `--community`, `--all`)
@@ -118,7 +118,7 @@ zenodo-cli/
    - `records versions <id>`
    - `communities list [query]`
    - `licenses search [query]`
-   - `access links list <id>`
+   - ~~`access links list <id>`~~ *(disabled v0.1)*
 6. Implement `--all` auto-pagination:
    - Loop through pages until exhausted or 10k ceiling
    - Rate-limit-aware delays between pages

--- a/.claude/reference/v0.1/RPD.md
+++ b/.claude/reference/v0.1/RPD.md
@@ -77,12 +77,12 @@ A Go CLI tool that wraps the Zenodo REST API for metadata management, asset inve
 | FR-4.1 | `communities list [query]` — search/list communities |
 | FR-4.2 | Support `--output json|table|csv` |
 
-### FR-5: Access Links
+### ~~FR-5: Access Links~~ *(disabled in v0.1 — read-only release)*
 
 | ID | Requirement |
 |----|-------------|
-| FR-5.1 | `access links list <id>` — list share links for a record |
-| FR-5.2 | Support `--output json|table|csv` |
+| ~~FR-5.1~~ | ~~`access links list <id>` — list share links for a record~~ |
+| ~~FR-5.2~~ | ~~Support `--output json|table|csv`~~ |
 
 ### FR-6: Licenses
 

--- a/internal/api/access.go
+++ b/internal/api/access.go
@@ -1,5 +1,9 @@
 package api
 
+// v0.1: Access links methods disabled — read-only release.
+// They will be re-enabled in a future version.
+
+/*
 import (
 	"fmt"
 
@@ -14,3 +18,4 @@ func (c *Client) ListAccessLinks(recordID int) ([]model.AccessLink, error) {
 	}
 	return result.Hits.Hits, nil
 }
+*/

--- a/internal/api/access_test.go
+++ b/internal/api/access_test.go
@@ -1,5 +1,8 @@
 package api
 
+// v0.1: Access links tests disabled — read-only release.
+
+/*
 import (
 	"encoding/json"
 	"net/http"
@@ -35,3 +38,4 @@ func TestListAccessLinks(t *testing.T) {
 		t.Errorf("id = %q", links[0].ID)
 	}
 }
+*/

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -1,5 +1,9 @@
 package cli
 
+// v0.1: Access links commands disabled — read-only release.
+// They will be re-enabled in a future version.
+
+/*
 import (
 	"fmt"
 	"os"
@@ -49,3 +53,4 @@ func init() {
 	accessCmd.AddCommand(accessLinksCmd)
 	rootCmd.AddCommand(accessCmd)
 }
+*/


### PR DESCRIPTION
## Summary
- Comment out `access links list` CLI command, `ListAccessLinks` API method, and associated test
- Mark FR-5 (Access Links) as disabled/struck-through in RPD.md
- Annotate access.go references in PLAN.md and DEVELOP.md as disabled for v0.1

## ELI5
The access links feature lets you list secret share links on Zenodo records. Since v0.1 is a read-only release and this command isn't needed yet, we're hiding it — same as we did with the deposit write commands. The code is still there (just commented out) so we can turn it back on later.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `zenodo.exe` no longer shows `access` in help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)